### PR TITLE
Wildcard expansion error in pre-process.sh

### DIFF
--- a/createModel.sh
+++ b/createModel.sh
@@ -7,59 +7,19 @@ mkdir result_vector
 data=$1
 inFilestr=${data##*/}
 echo $inFilestr
-# default setting from word2vec, except iter (time issue)
-word2vec/word2vec -train $data -output result_vector/$inFilestr-default-skipGram.bin -size 100 -window 5 -sample 1e-3 -negative 5 -hs 0 -binary 1 -cbow 0 -iter 1 -threads 12 -min-count 5 -alpha 0.025 
 
-#cbow vs skip-gram
-word2vec/word2vec -train $data -output result_vector/$inFilestr-default-cbow.bin -size 100 -window 5 -sample 1e-3 -negative 5 -hs 0 -binary 1 -cbow 1 -iter 1 -threads 12 -min-count 5 -alpha 0.025 
+#various parameters
+win=("2")
+dim=("200")
+neg=("10")
+samp=("1e-4")
+min=("5" "10" "20" "50" "100" "200" "400" "800" "1000" "1200" "2400")
+alpha=("0.05")
 
-#various parameter
-win=("1" "2" "4" "5" "8" "16" "20" "25" "30")
-dim=("25" "50" "100" "200" "400" "500" "800")
-neg=("1" "2" "3" "5" "8" "10" "15")
-samp=("0" "1e-1" "1e-2" "1e-3" "1e-4" "1e-5" "1e-6" "1e-6" "1e-7" "1e-8" "1e-9" '1e-10')
-min=("0" "5" "10" "20" "50" "100" "200" "400" "800" "1000" "1200" "2400")
-alpha=("0.05" "0.025" "0.0125" "0.1" "0.2" "0.5")
-
-for i in "${win[@]}" ; do
-	echo 'window size:' $i
-	echo -train $data -output result_vector/$inFilestr-win$i.bin -size 100 -window $i -sample 1e-3 -negative 5 -hs 0 -binary 1 -cbow 0 -iter 1 -threads 12 -min-count 5 -alpha 0.025
-	word2vec/word2vec -train $data -output result_vector/$inFilestr-win$i.bin -size 100 -window $i -sample 1e-3 -negative 5 -hs 0 -binary 1 -cbow 0 -iter 1 -threads 12 -min-count 5 -alpha 0.025 
-
-done
-
-for i in "${dim[@]}" ; do
-	echo 'vector length:' $i
-	echo -train $data -output $inFilestr-dim$i.bin -size $i -window 5 -sample 1e-3 -negative 5 -hs 0 -binary 1 -cbow 0 -iter 1 -threads 12 -min-count 5 -alpha 0.025
-	word2vec/word2vec -train $data -output result_vector/$inFilestr-dim$i.bin -size $i -window 5 -sample 1e-3 -negative 5 -hs 0 -binary 1 -cbow 0 -iter 1 -threads 12 -min-count 5 -alpha 0.025 
-
-done
-#wait
-
-for i in "${neg[@]}" ; do
-	echo 'negative sampling:' $i
-	echo -train $data -output $inFilestr-neg$i.bin -size 100 -window 5 -sample 1e-3 -negative $i -hs 0 -binary 1 -cbow 0 -iter 1 -threads 12 -min-count 5 -alpha 0.025
-	word2vec/word2vec -train $data -output result_vector/$inFilestr-neg$i.bin -size 100 -window 5 -sample 1e-3 -negative $i -hs 0 -binary 1 -cbow 0 -iter 1 -threads 12 -min-count 5 -alpha 0.025 
-done
-#wait
-
-for i in "${samp[@]}" ; do
-	echo 'sampling:' $i
-	echo -train $data -output $inFilestr-samp$i.bin -size 100 -window 5 -sample $i -negative 5 -hs 0 -binary 1 -cbow 0 -iter 1 -threads 12 -min-count 5 -alpha 0.025
-	word2vec/word2vec -train $data -output result_vector/$inFilestr-samp$i.bin -size 100 -window 5 -sample $i -negative 5 -hs 0 -binary 1 -cbow 0 -iter 1 -threads 12 -min-count 5 -alpha 0.025 
-done
-#wait
 
 for i in "${min[@]}" ; do
 	echo 'Min Count:' $i
-	echo -train $data -output $inFilestr-min$i.bin -size 100 -window 5 -sample 1e-3 -negative 5 -hs 0 -binary 1 -cbow 0 -iter 1 -threads 12 -min-count $i -alpha 0.025
-	word2vec/word2vec -train $data -output result_vector/$inFilestr-min$i.bin -size 100 -window 5 -sample 1e-3 -negative 5 -hs 0 -binary 1 -cbow 0 -iter 1 -threads 12 -min-count $i -alpha 0.025 
-done
-#wait
-
-for i in "${alpha[@]}" ; do
-	echo 'alpha:' $i
-	echo -train $data -output $inFilestr-alpha$i.bin -size 100 -window 5 -sample 1e-3 -negative 5 -hs 0 -binary 1 -cbow 0 -iter 1 -threads 12 -min-count 5 -alpha $i
-	word2vec/word2vec -train $data -output result_vector/$inFilestr-alpha$i.bin -size 100 -window 5 -sample 1e-3 -negative 5 -hs 0 -binary 1 -cbow 0 -iter 1 -threads 12 -min-count 5 -alpha $i 
+	echo -train $data -output $inFilestr-min$i.bin -size 200 -window 2 -sample 1e-4 -negative 10 -hs 0 -binary 1 -cbow 0 -iter 1 -threads 12 -min-count $i -alpha 0.05
+	word2vec/word2vec -train $data -output result_vector/$inFilestr-min$i.bin -size 200 -window 2 -sample 1e-4 -negative 10 -hs 0 -binary 1 -cbow 0 -iter 1 -threads 12 -min-count $i -alpha 0.05
 done
 wait

--- a/create_shf_low_text.sh
+++ b/create_shf_low_text.sh
@@ -11,4 +11,4 @@ cat $1 | perl -MList::Util=shuffle -e 'print shuffle(<STDIN>);' > shuffled_$1
 tr '[:upper:]' '[:lower:]' < $1 > lower_$1
 
 # create Lowercased + shuffled text 
-cat lower_$1 shuffled_$1 > low_shuff_$1
+tr '[:upper:]' '[:lower:]' < shuffled_$1 > low_shuff_$1

--- a/get_PubMed.sh
+++ b/get_PubMed.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+mkdir pubmedfiles
+cd pubmedfiles
+wget ftp://ftp.ncbi.nlm.nih.gov/pubmed/baseline/*000*.gz
+
+echo 'Unzipping files.'
+gunzip '*.gz'
+cd ../../
+
+git clone https://github.com/spyysalo/pubmed.git
+
+mv -v pubmed/scripts/* pubmed/
+
+cd BioNLP-2016/
+
+mkdir pubmedtxt
+cd pubmedtxt/
+
+../../pubmed/extract-and-pack.sh *.xml
+for file in `ls *.tar.gz`; do tar -xf $file; done

--- a/get_PubMed.sh
+++ b/get_PubMed.sh
@@ -4,7 +4,7 @@ mkdir pubmedfiles
 cd pubmedfiles
 
 echo 'Downloading files'
-wget ftp://ftp.ncbi.nlm.nih.gov/pubmed/baseline/*000*.gz
+wget ftp://ftp.ncbi.nlm.nih.gov/pubmed/baseline/*.gz
 
 echo 'Unzipping files.'
 gunzip *.gz
@@ -28,3 +28,7 @@ for file in `ls *.tar.gz`; do tar -xf $file; done
 
 echo 'Removing .tar.gz files.'
 rm *.tar.gz
+
+for folder in */ ; do
+mv $folder/* . && rmdir $folder
+done

--- a/get_PubMed.sh
+++ b/get_PubMed.sh
@@ -2,20 +2,29 @@
 
 mkdir pubmedfiles
 cd pubmedfiles
+
+echo 'Downloading files'
 wget ftp://ftp.ncbi.nlm.nih.gov/pubmed/baseline/*000*.gz
 
 echo 'Unzipping files.'
-gunzip '*.gz'
+gunzip *.gz
 cd ../../
 
+echo 'Downloading pubmed tools.'
 git clone https://github.com/spyysalo/pubmed.git
 
-mv -v pubmed/scripts/* pubmed/
+mv -v ./pubmed/scripts/* ./pubmed/
 
 cd BioNLP-2016/
 
 mkdir pubmedtxt
 cd pubmedtxt/
 
-../../pubmed/extract-and-pack.sh *.xml
+echo 'Exctracting text from xml'
+../../pubmed/extract-and-pack.sh ../pubmedfiles/*.xml
+
+echo 'Unzipping tar.gz.'
 for file in `ls *.tar.gz`; do tar -xf $file; done
+
+echo 'Removing .tar.gz files.'
+rm *.tar.gz

--- a/pre-process.sh
+++ b/pre-process.sh
@@ -31,4 +31,4 @@ python tokenize_Text.py $file tokenizeText/$inFilestr
 done
 
 cd tokenizeText/
-cat *.txt > ../combine_tokenized.txt
+cat '*.txt' > ../combine_tokenized.txt

--- a/pre-process.sh
+++ b/pre-process.sh
@@ -8,7 +8,7 @@ mkdir segmentText
 
 echo 'sentence spliting'
 Dir=$1
-FILES=$(find $Dir -name *.txt)
+FILES=$(find $Dir -name '*.txt')
 
 for file in $FILES
 do
@@ -22,7 +22,7 @@ cd ..
 mkdir tokenizeText
 echo 'Tokenise'
 Dir=geniass/segmentText/
-FILES=$(find $Dir -name *.txt)
+FILES=$(find $Dir -name '*.txt')
 for file in $FILES ; do
 inFilestr=${file##*/}
 echo $inFilestr


### PR DESCRIPTION
Added quotation marks to *.txt to handle some shell's wildcard expansion when attempting to execute $(find $Dir -name *.txt)